### PR TITLE
Fix: Multiprocessing unable to stop

### DIFF
--- a/src/ppk2_api/ppk2_api.py
+++ b/src/ppk2_api/ppk2_api.py
@@ -472,7 +472,7 @@ class PPK2_MP(PPK2_API):
 
     def stop_measuring(self):
         PPK2_API.stop_measuring(self)
-        PPK2_API.get_data(self) # flush the serial buffer (to prevent unicode error on next command)
+        PPK2_MP.get_data(self) # flush the serial buffer (to prevent unicode error on next command)
         self._quit_evt.set()
         if self._fetcher is not None:
             self._fetcher.join() # join() will block if the queue isn't empty

--- a/src/ppk2_api/ppk2_api.py
+++ b/src/ppk2_api/ppk2_api.py
@@ -472,7 +472,7 @@ class PPK2_MP(PPK2_API):
 
     def stop_measuring(self):
         PPK2_API.stop_measuring(self)
-        PPK2_MP.get_data(self) # flush the serial buffer (to prevent unicode error on next command)
+        self.get_data() # flush the serial buffer (to prevent unicode error on next command)
         self._quit_evt.set()
         if self._fetcher is not None:
             self._fetcher.join() # join() will block if the queue isn't empty


### PR DESCRIPTION
Not sure if this is the best way to fix this, but this fixed Issue #13. I assume this was the intention as the function below (get_data) isn't called anywhere else. Someone more fluent in python should confirm this.