### PR TITLE
list_devices: prints serial when discovering ppk2

### DIFF
--- a/example.py
+++ b/example.py
@@ -10,11 +10,12 @@ import time
 from ppk2_api.ppk2_api import PPK2_API
 
 ppk2s_connected = PPK2_API.list_devices()
-if(len(ppk2s_connected) == 1):
-    ppk2_port = ppk2s_connected[0]
-    print(f'Found PPK2 at {ppk2_port}')
+if len(ppk2s_connected) == 1:
+    ppk2_port = ppk2s_connected[0][0]
+    ppk2_serial = ppk2s_connected[0][1]
+    print(f"Found PPK2 at {ppk2_port} with serial number {ppk2_serial}")
 else:
-    print(f'Too many connected PPK2\'s: {ppk2s_connected}')
+    print(f"Too many connected PPK2's: {ppk2s_connected}")
     exit()
 
 ppk2_test = PPK2_API(ppk2_port, timeout=1, write_timeout=1, exclusive=True)

--- a/example_mp.py
+++ b/example_mp.py
@@ -10,11 +10,12 @@ import time
 from ppk2_api.ppk2_api import PPK2_MP as PPK2_API
 
 ppk2s_connected = PPK2_API.list_devices()
-if(len(ppk2s_connected) == 1):
-    ppk2_port = ppk2s_connected[0]
-    print(f'Found PPK2 at {ppk2_port}')
+if len(ppk2s_connected) == 1:
+    ppk2_port = ppk2s_connected[0][0]
+    ppk2_serial = ppk2s_connected[0][1]
+    print(f"Found PPK2 at {ppk2_port} with serial number {ppk2_serial}")
 else:
-    print(f'Too many connected PPK2\'s: {ppk2s_connected}')
+    print(f"Too many connected PPK2's: {ppk2s_connected}")
     exit()
 
 ppk2_test = PPK2_API(ppk2_port, buffer_max_size_seconds=1, buffer_chunk_seconds=0.01, timeout=1, write_timeout=1, exclusive=True)

--- a/src/ppk2_api/ppk2_api.py
+++ b/src/ppk2_api/ppk2_api.py
@@ -213,11 +213,20 @@ class PPK2_API():
     @staticmethod
     def list_devices():
         import serial.tools.list_ports
+
         ports = serial.tools.list_ports.comports()
-        if os.name == 'nt':
-            devices = [port.device for port in ports if port.description.startswith("nRF Connect USB CDC ACM")]
+        if os.name == "nt":
+            devices = [
+                (port.device, port.serial_number[:8])
+                for port in ports
+                if port.description.startswith("nRF Connect USB CDC ACM")
+            ]
         else:
-            devices = [port.device for port in ports if port.product == 'PPK2']
+            devices = [
+                (port.device, port.serial_number[:8])
+                for port in ports
+                if port.product == "PPK2"
+            ]
         return devices
 
     def get_data(self):


### PR DESCRIPTION
This commit adds an extra field to the return from `list_devices` with the serial number of the discovered device. Added printing of the serial in the examples, as requested in https://github.com/IRNAS/ppk2-api-python/issues/41.

Output from example.py

```
> py example.py
Found PPK2 at /dev/ttyACM0 with serial number C10A56B6
Average of 512 samples is: -1.3063051170568183uA
[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
(...)
```