### PR TITLE
list_devices: adds support for several com ports

### DIFF
--- a/src/ppk2_api/ppk2_api.py
+++ b/src/ppk2_api/ppk2_api.py
@@ -219,13 +219,13 @@ class PPK2_API():
             devices = [
                 (port.device, port.serial_number[:8])
                 for port in ports
-                if port.description.startswith("nRF Connect USB CDC ACM")
+                if port.description.startswith("nRF Connect USB CDC ACM") and port.location.endswith("1")
             ]
         else:
             devices = [
                 (port.device, port.serial_number[:8])
                 for port in ports
-                if port.product == "PPK2"
+                if port.product == "PPK2" and port.location.endswith("1")
             ]
         return devices
 


### PR DESCRIPTION
After the firmware change in the official PPK2 application 4.2.0, the device now enumerates two serial ports: one for data and commands, the other for a debug shell which is not used in this library. This forces connection with the port on endpoint 1.