### PR TITLE
fix: handle reconnect get_modifiers

### DIFF
--- a/src/ppk2_api/ppk2_api.py
+++ b/src/ppk2_api/ppk2_api.py
@@ -158,8 +158,8 @@ class PPK2_API():
             time.sleep(0.1)
 
             # TODO add a read_until serial read function with a timeout
-            if read != b'' and "END" in read.decode("utf-8"):
-                return read.decode("utf-8")
+            if read != b'' and "END" in read.decode("utf-8", errors="replace"):
+                return read.decode("utf-8", errors="replace")
 
     def _parse_metadata(self, metadata):
         """Parse metadata and store it to modifiers"""


### PR DESCRIPTION
After updating the firmware on my PPK2 to v4.2.0 I noticed that connecting, disconnected then trying to reconnect failed. It seems like the updated firmware has some `0x81` byte that gets send and as a result an exception gets thrown.

This commit allows those bytes to be replaced, thus the check is still valid but we do not get this exception.

This was discovered with the following version:

```
ppk2-api==0.9.2
```

## Error Traceback
```
  File "/home/weiss/repos/lobaro/python-lob-ppk/.venv/lib/python3.10/site-packages/ppk2_api/ppk2_api.py", line 228, in get_modifiers
    metadata = self._read_metadata()
  File "/home/weiss/repos/lobaro/python-lob-ppk/.venv/lib/python3.10/site-packages/ppk2_api/ppk2_api.py", line 158, in _read_metadata
    if read != b'' and "END" in read.decode("utf-8"):
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x81 in position 130: invalid start byte
```